### PR TITLE
Add support for comments being null or undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,13 @@ module.exports = attachComments
 var push = [].push
 
 function attachComments(tree, comments) {
-  walk(tree, {comments: comments.concat().sort(compare), index: 0})
+  walk(tree, {
+    comments:
+      comments === null || comments === undefined
+        ? []
+        : comments.concat().sort(compare),
+    index: 0
+  })
   return tree
 }
 

--- a/test.js
+++ b/test.js
@@ -8,6 +8,21 @@ var attachComments = require('.')
 
 test('estree-attach-comments (recast)', function (t) {
   t.equal(
+    recast.print(attachComments(acorn.parse('', {ecmaVersion: 2020}), null))
+      .code,
+    '',
+    'should support null comments'
+  )
+
+  t.equal(
+    recast.print(
+      attachComments(acorn.parse('', {ecmaVersion: 2020}), undefined)
+    ).code,
+    '',
+    'should support undefined comments'
+  )
+
+  t.equal(
     recast.print(attachComments(...parse(''))).code,
     '',
     'should support an empty document'


### PR DESCRIPTION
In estree comments are optional. Not allowing nullish values causes bugs downstream.