### PR TITLE
feat: support EstreeNode comments

### DIFF
--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ import {attachComments} from './index.js'
 /**
  * @typedef {import('estree').BaseNode} EstreeNode
  * @typedef {import('estree').Program} EstreeProgram
- * @typedef {import('estree').Comment} EstreeComment
+ * @typedef {import('estree').Comment & {leading: boolean, trailing: boolean}} EstreeComment
  */
 
 test('estree-attach-comments (recast)', function (t) {


### PR DESCRIPTION
Fixes #5 

I set the default value to `false`, but this is in my opinion a surprising behavior as Estree expects the comments to be on `leadingComments` and `trailingComments`.